### PR TITLE
Disable JAWTTest on Linux too.

### DIFF
--- a/src/test/java/org/bridj/JAWTTest.java
+++ b/src/test/java/org/bridj/JAWTTest.java
@@ -46,7 +46,7 @@ public class JAWTTest {
 	
 	@Test
 	public void testWindowPeer() throws Exception {
-    if (Platform.isMacOSX() ||
+    if (Platform.isMacOSX() || Platform.isLinux() ||
         System.getProperty("java.version").matches("1\\.6\\..*")) {
       // Oracle Java and jawt: it's complicated.
       // See http://forum.lwjgl.org/index.php?topic=4326.0


### PR DESCRIPTION
From the source comment it seems that OSX and OpenJDK 1.6 are known to
be problematic, but I also get the failure on OpenJDK 1.7.
Assuming that it doesn't just work on Linux (or it could be working on
Oracle JDK but no idea how to detect and fix that).
So far disabling this.