### PR TITLE
Fix gcc4 mangling complex constchar

### DIFF
--- a/src/main/java/org/bridj/demangling/GCC4Demangler.java
+++ b/src/main/java/org/bridj/demangling/GCC4Demangler.java
@@ -118,7 +118,7 @@ public class GCC4Demangler extends Demangler {
     public TypeRef parseType() throws DemanglingException {
         if (Character.isDigit(peekChar())) {
             Ident name = ensureOfType(parseNonCompoundIdent(), Ident.class);
-            String id = nextShortcutId(); // we get the id before parsing the part (might be template parameters and we need to get the ids in the right order)
+            String id = nextShortcutId();
             TypeRef res = simpleType(name);
             typeShortcuts.put(id, res);
             return res;
@@ -152,8 +152,9 @@ public class GCC4Demangler extends Demangler {
                                 return typeShortcuts.get(templatedId);
                             }
                         }
+                    } else {
+                        position -= delta;
                     }
-                    position -= delta;
                 }
             }
             // WARNING/INFO/NB: we intentionally continue to the N case

--- a/src/main/java/org/bridj/demangling/GCC4Demangler.java
+++ b/src/main/java/org/bridj/demangling/GCC4Demangler.java
@@ -62,7 +62,7 @@ public class GCC4Demangler extends Demangler {
             // Ss == std::string == std::basic_string<char, std::char_traits<char>, std::allocator<char> >        
             put("s", Arrays.asList((IdentLike) new Ident("std"), new Ident("basic_string", new TemplateArg[]{classType(Byte.TYPE), charTraitsOfChar, allocatorOfChar})));
 
-            // used, as an helper: for i in a b c d e f g h i j k l m o p q r s t u v w x y z; do c++filt _Z1_S$i; done
+            // used, as an helper: for i in {a..z}; do echo $i $(c++filt _Z1_S$i); done
         }
 
         private ClassRef enclosed(String ns, ClassRef classRef) {

--- a/src/test/java/org/bridj/DemanglingTest.java
+++ b/src/test/java/org/bridj/DemanglingTest.java
@@ -466,7 +466,7 @@ TEST_API void repeatedCall8(const short*, const short*, const char*, const char*
         demangle(null, "_ZN3bla5inputEPSt6vectorISsSaISsEEPS0_IPN7Helping4HandESaIS6_EE",
                 // bla::input(std::vector<std::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::basic_string<char, std::char_traits<char>, std::allocator<char> > > >*, std::vector<Helping::Hand*, std::allocator<Helping::Hand*> >*)
                 // bla::input(vectorof(string)*, vectorof(Helping::Hand*)*)
-                "null bla.input(std.vector<std.basic_string<byte, std.char_traits<byte>, std.allocator<byte>>, std.allocator<std.basic_string<byte, std.char_traits<byte>, std.allocator<byte>>>>*, std.allocator<std.basic_string<byte, std.char_traits<byte>, std.allocator<byte>>><Helping.Hand*, std.allocator<Helping.Hand*>>*)");
+                "null bla.input(std.vector<std.basic_string<byte, std.char_traits<byte>, std.allocator<byte>>, std.allocator<std.basic_string<byte, std.char_traits<byte>, std.allocator<byte>>>>*, std.vector<Helping.Hand*, std.allocator<Helping.Hand*>>*)");
                 //"null bla.input(" + vectorOfXYZ.replaceAll("XYZ", str) + "*, " + vectorOfXYZ.replaceAll("XYZ", "Helping.Hand*") + "*)");
     }
 

--- a/src/test/java/org/bridj/DemanglingTest.java
+++ b/src/test/java/org/bridj/DemanglingTest.java
@@ -311,6 +311,10 @@ public class DemanglingTest {
             pointerType(pointerType(Byte.class))
         );
 	}
+    @Test
+	public void twiceConstCharPointerFromBugRequests() {
+        demangle(null, "_ZN16cmd_create_event6createEPKcS1_PS1_", "null cmd_create_event.create(const byte*, const byte*, const byte**)");
+	}
 	@Test
     public void methods() {
     	demangle(


### PR DESCRIPTION
Following mails reporting issues on the mailing list (replicated below), I fixed the "const char*" problems that appear as soon as the case is not trivial. I added the provided example as a test.

@ochafik : it has been tested only with "mvn -Dtest=org.bridj.DemanglingTest test", so it might be worth testing on a wider scope before merging.


~~~
On Monday, July 27, 2015 at 12:17:50 PM UTC-7, Kurt Granroth wrote:

   I'm using com.nativelibs4java.bridj.0.7.0 on a CentOS 5 system
   running Java 1.8.  gcc version 4.1.2; x64

   Let's say I have a C++ method like so:

   bool create( const char *template, const char *name);

   When linked into a shared library, it gets mangled into this:

   _ZN16cmd_create_event6createEPKcS1_


   This mangled name appears correct in that I can link to it from
   another C++ app with on problem.  Also, running 'nm --demangle' on
   the shared lib correctly demangles that name to the proper one.


   When I try to use this shared library with bridj, though, I get this
   error:


   org.bridj.demangling.Demangler$DemanglingException: Encountered a
   unexpected gcc mangler shortcut '1_' [a, b, s, t, d, i, o, _, 0_]
   (in symbol '_ZN16cmd_create_event6createEPKcS1_')


   That's not the only function that behaves like this -- I see
   hundreds of these errors for that library.


   I was able to work around that particular case by replacing the two
   string parameters with one struct, which had the two strings as
   member variables.  That works, if non-ideally.


   But I can't replace all 'const char*' instances with structs.
     Here's another example:


   const char *error() const;


   That's mangled into:


   _ZNK16cmd_create_event5errorEv


   The bridj parser doesn't like that one, either:


   org.bridj.demangling.Demangler$DemanglingException: Parsing error at
   position 3: Expected a number

            _ZNK16cmd_create_event5errorEv

               ^ (in symbol '_ZNK16cmd_create_event5errorEv')


   I'm not sure what to do in these cases.  Using the 'Symbol'
   annotation workaround doesn't help, since it's not so much a mapping
   problem as the fact that the bridj demangler doesn't think my
   methods are valid.


   Thoughts?
~~~
