### PR TITLE
Recreate temp directory if it doesn't exist

### DIFF
--- a/src/main/java/org/bridj/Platform.java
+++ b/src/main/java/org/bridj/Platform.java
@@ -690,6 +690,11 @@ public class Platform {
                 continue;
             }
             String fileName = new File(libraryResource).getName();
+            
+            if (!extractedLibrariesTempDir.exists()) {
+                extractedLibrariesTempDir = createTempDir("BridJExtractedLibraries");
+            }
+            
             File libFile = new File(extractedLibrariesTempDir, fileName);
             OutputStream out = new BufferedOutputStream(new FileOutputStream(libFile));
             while ((len = in.read(b)) > 0) {


### PR DESCRIPTION
This is a fix for a failure we see when invoking bridj multiple times from Maven, after a first invocation this temp directory won't exist.

This fixes the issue by recreating the temp directory if it doesn't exist.