### PR TITLE
Static annotation for factory methods

### DIFF
--- a/src/main/java/org/bridj/MethodCallInfo.java
+++ b/src/main/java/org/bridj/MethodCallInfo.java
@@ -73,6 +73,7 @@ import org.bridj.ann.Convention;
 import org.bridj.ann.DisableDirect;
 import org.bridj.ann.Ptr;
 import org.bridj.ann.SetsLastError;
+import org.bridj.ann.Static;
 import org.bridj.ann.Virtual;
 import org.bridj.dyncall.DyncallLibrary.DCstruct;
 import org.bridj.util.Utils;
@@ -143,7 +144,8 @@ public class MethodCallInfo {
         symbolName = methodName;
 
         int modifiers = method.getModifiers();
-        isStatic = Modifier.isStatic(modifiers);
+        isStatic = method.getAnnotation(Static.class) != null 
+            || Modifier.isStatic(modifiers);
         isVarArgs = method.isVarArgs();
         boolean isNative = Modifier.isNative(modifiers);
         boolean isVirtual = isAnnotationPresent(Virtual.class, definition);

--- a/src/main/java/org/bridj/StructFieldDeclaration.java
+++ b/src/main/java/org/bridj/StructFieldDeclaration.java
@@ -43,6 +43,7 @@ import org.bridj.ann.Alignment;
 import org.bridj.ann.Array;
 import org.bridj.ann.Bits;
 import org.bridj.ann.Field;
+import org.bridj.ann.Static;
 import org.bridj.ann.Union;
 
 class StructFieldDeclaration {
@@ -69,7 +70,8 @@ class StructFieldDeclaration {
 
         int modifiers = member.getModifiers();
 
-        return !Modifier.isStatic(modifiers);
+        return !(((AnnotatedElement) member).getAnnotation(Static.class) != null
+            || Modifier.isStatic(modifiers));
     }
 
     /**

--- a/src/main/java/org/bridj/ann/Static.java
+++ b/src/main/java/org/bridj/ann/Static.java
@@ -1,0 +1,15 @@
+package org.bridj.ann;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Applies to native methods to indicate that they should be treated as
+ * static.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD, ElementType.TYPE})
+public @interface Static {
+}

--- a/src/main/java/org/bridj/objc/ObjectiveCRuntime.java
+++ b/src/main/java/org/bridj/objc/ObjectiveCRuntime.java
@@ -58,7 +58,9 @@ import org.bridj.Platform;
 import org.bridj.Pointer;
 import org.bridj.Pointer.Releaser;
 import org.bridj.ann.Library;
+import org.bridj.ann.Name;
 import org.bridj.ann.Ptr;
+import org.bridj.ann.Static;
 import org.bridj.demangling.Demangler;
 import org.bridj.util.Utils;
 
@@ -283,7 +285,7 @@ public class ObjectiveCRuntime extends CRuntime {
 
         try {
             MethodCallInfo mci = methodCallInfoBuilder.apply(method);
-            boolean isStatic = Modifier.isStatic(method.getModifiers());
+            boolean isStatic = method.getAnnotation(Static.class) != null || Modifier.isStatic(method.getModifiers());
 
             if (isStatic) {
                 Pointer<ObjCClass> pObjcClass = getObjCClass((Class) type).as(ObjCClass.class);
@@ -416,6 +418,7 @@ public class ObjectiveCRuntime extends CRuntime {
             return getObjCClass("NSObject", false);
         }
 
-        return getObjCClass(cls.getSimpleName(), false);
+        Name name = cls.getAnnotation(Name.class);
+        return getObjCClass(name == null ? cls.getSimpleName() : name.value(), false);
     }
 }


### PR DESCRIPTION
This PR adds a new @Static annotation indicating that a method is to be treated as static even when it isn't. This is in order to be able to use the Objective-C bindings from Scala companion objects, whose method implementations are not actually static. For example, the following can now be expressed in Scala:

```scala
  @Library("Foundation")
  @Name("NSMutableArray")
  object NSMutableArray extends ObjCClass {
    BridJ.register(classOf[NSMutableArray[_]])

    @Static @native def arrayWithCapacity(capacity: Int): Pointer[NSMutableArray[_]]
  }

  class NSMutableArray[T <: NSObject : ClassTag] extends NSArray[T] {
    @native def removeLastObject(): Unit
    @native def removeAllObjects(): Unit
  }
```
